### PR TITLE
[Feature] Windows Build Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,28 @@ Framework for Assignments: Web Technology at VU Amsterdam
 This is a template to be used for each assignment during the course. For details on the assignments and their requirements, see the [canvas page](https://canvas.vu.nl/courses/83680). 
 
 ## Submission
-In order to submit, you need to create a zip file of each stage in your project. To do this, we have a basic Makefile that you can use.
+In order to submit, you need to create a zip file of each stage in your project. To do this, we have a basic Makefile (for Linux/Mac) and a `build.bat` script (for Windows) that you can use.
+
+### Unix (Linux/MacOS)
 - First, make sure you have `zip` installed. On Ubuntu, you can do this by running `sudo apt install zip`.
-- Then, in the make file, change the value of the "labNumber" variable to your own lab number
+- Then, in the Makefile, change the value of the "labNumber" variable to your own lab number
 - Each assignment has a different command
   - `make a1` for assignment 1
   - `make a2` for assignment 2
   - `make a3` for assignment 3
+  - `make all` to build all the assignments
+
+- Once submitted you can also run `make clean` to delete the zip files.
+
+### Windows
+- In the `build.bat` file, change the value of the "labNumber" variable to your own lab number.
+- Each assignment has a different command (run these in PowerShell or cmd):
+  - `.\build.bat a1` for assignment 1
+  - `.\build.bat a2` for assignment 2
+  - `.\build.bat a3` for assignment 3
+  - `.\build.bat all` to build all the assignments
+
+- Once submitted you can also run `.\build.bat clean` to delete the zip files.
 
 The naming of the files is important for assignment 1 as your `.html` and `.css` files are checked using CodeGrade's AutoTesting, so please don't change their names.
 

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,51 @@
+@echo off
+setlocal
+
+rem Set your lab number here
+set "labNumber=0"
+
+rem Pad the lab number with leading zeros (up to 3 digits)
+set "labNumberPadded=00%labNumber%"
+set "labNumberPadded=%labNumberPadded:~-3%"
+
+set "a1_zip=a1-lab%labNumberPadded%.zip"
+set "a2_zip=a2-lab%labNumberPadded%.zip"
+set "a3_zip=a3-lab%labNumberPadded%.zip"
+
+rem Default target
+if "%1"=="" goto all
+if /i "%1"=="all" goto all
+if /i "%1"=="a1" goto a1
+if /i "%1"=="a2" goto a2
+if /i "%1"=="a3" goto a3
+if /i "%1"=="clean" goto clean
+
+echo Invalid target: %1
+exit /b 1
+
+:all
+call :a1
+call :a2
+call :a3
+goto :eof
+
+:a1
+if exist "%a1_zip%" del "%a1_zip%"
+tar -a -c -f "%a1_zip%" "a1-markup/index.html" "a1-markup/style.css" "a1-markup/report.md"
+goto :eof
+
+:a2
+if exist "%a2_zip%" del "%a2_zip%"
+tar -a -c -f "%a2_zip%" "a2-scripting"
+goto :eof
+
+:a3
+if exist "%a3_zip%" del "%a3_zip%"
+tar -a -c -f "%a3_zip%" --exclude "a3-server/node_modules" --exclude "a3-server/package-lock.json" --exclude "a3-server/media.db" "a3-server"
+goto :eof
+
+:clean
+if exist "%a1_zip%" del "%a1_zip%"
+if exist "%a2_zip%" del "%a2_zip%"
+if exist "%a3_zip%" del "%a3_zip%"
+goto :eof


### PR DESCRIPTION
Good evening Dr. van Ossenbruggen

While working on the A1 submission, I realized that the build system via Make doesn't work on Windows, even after installing GNU Make (through `choco install make`). It would be possible to port the Makefile such that it works on windows but instead I opted to just create a batch file instead, which avoids the mental gymnastics of "am I running the right makefile?".

The two build systems should have feature parity. I'm also using tar, which should be including by default in mordern Windows 10 and beyond.

I have tested the batch script by compressing and decompressing them, and by creating a submission on Codegrade, where all the test cases seem to pass just fine.

Apologies if I have missed something, I don't usually write batch scripts.